### PR TITLE
Update settings change callback registration

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -99,7 +99,7 @@ class MycroftChat(MycroftSkill):
                     self.monitoring = False
 
         # Check and then monitor for credential changes
-        self.settings.set_changed_callback(self.on_websettings_changed)
+        self.settings_change_callback = self.on_websettings_changed
 
     def on_websettings_changed(self):
         LOG.debug("websettings changed!")


### PR DESCRIPTION
For 20.02 we'd like to remove the old deprecated method for registering the settings changed callback. This switches to the new method.